### PR TITLE
Fixed random duplicate keys in tests

### DIFF
--- a/test/unit/BuildSqlRecordValuesCapableTraitTest.php
+++ b/test/unit/BuildSqlRecordValuesCapableTraitTest.php
@@ -105,9 +105,9 @@ class BuildSqlRecordValuesCapableTraitTest extends TestCase
         $subject = $this->createInstance();
         $reflect = $this->reflect($subject);
 
-        $val1 = rand(0, 50);
+        $val1 = rand(0, 30);
         $val2 = uniqid('str-');
-        $val3 = rand(30, 100);
+        $val3 = rand(50, 100);
         $hash1 = uniqid('hash1-');
         $hash2 = uniqid('hash2-');
         $hash3 = uniqid('hash3-');
@@ -151,9 +151,9 @@ class BuildSqlRecordValuesCapableTraitTest extends TestCase
         $subject = $this->createInstance();
         $reflect = $this->reflect($subject);
 
-        $val1 = rand(0, 50);
+        $val1 = rand(0, 30);
         $val2 = uniqid('str-');
-        $val3 = rand(30, 100);
+        $val3 = rand(50, 100);
         $hash1 = uniqid('hash1-');
         $hash2 = uniqid('hash2-');
         $hash3 = uniqid('hash3-');


### PR DESCRIPTION
Changed random values that are also used as array keys to not collide and cause accidental overwriting. This should solve the irregular random failure of the tests.