### PR TITLE
Fixes test for negative offset building

### DIFF
--- a/test/unit/BuildSqlOffsetCapableTraitTest.php
+++ b/test/unit/BuildSqlOffsetCapableTraitTest.php
@@ -101,7 +101,7 @@ class BuildSqlOffsetCapableTraitTest extends TestCase
         $subject = $this->createInstance();
         $reflect = $this->reflect($subject);
 
-        $arg = - rand(0, 100);
+        $arg = - rand(1, 100);
         $subject->method('_normalizeInt')->willReturn($arg);
 
         $this->setExpectedException('OutOfRangeException');


### PR DESCRIPTION
Fixes the test for building offsets with a negative offset number. The randomized value had a chance to be `0`, which is not negative and is a valid offset.